### PR TITLE
Use postCopy instead of postInstall for cabal

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -12,9 +12,9 @@ import System.FilePath ((</>))
 import System.Posix.Files (createSymbolicLink)
 #endif
 
-main = defaultMainWithHooks simpleUserHooks {postInst = postInstall}
+main = defaultMainWithHooks simpleUserHooks {postCopy = postCopy'}
 
-postInstall _ _ _ buildInfo = do
+postCopy' _ _ _ buildInfo = do
   -- I tried the following seemingly more correct way but received the error:
   -- "internal error InstallDirs.libsubdir". For now I gave up on tracking it
   -- down and switched to the following code. If you know what I'm doing wrong


### PR DESCRIPTION
According to cabal maintainers "postInstall is semi-deprecated and a historical accident; older cabals call postInstall, newer don't". This results in `cabal install` not creating the correct redo-ifchange symlinks as expected and breaks our package.

As mentioned on #3 the package on Hackage is quite outdated and still not using the custom build type.

We probably need a version bump with this.

Many thanks to @hvr for helping me track this down.

Closes #3.